### PR TITLE
fix class getter setter syntax; add type

### DIFF
--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -48,8 +48,8 @@
   "Class-Getter": {
     "prefix": "ts-class-getter",
     "body": [
-      "private _$1:string",
-      "get $1(): string {",
+      "private _$1: $2",
+      "get $1(): $2 {",
       "  return this._$1;",
       "}"
     ],
@@ -58,9 +58,9 @@
   "Class-Setter": {
     "prefix": "ts-class-setter",
     "body": [
-      "private _$1:string",
-      "set $1(value): string {",
-      "  this._$1= value;",
+      "private _$1: $2",
+      "set $1(value: $2) {",
+      "  this._$1 = value;",
       "}"
     ],
     "description": "this will create a getter"
@@ -68,13 +68,13 @@
   "Class-Setter-Getter": {
     "prefix": "ts-class-setter-getter",
     "body": [
-      "private _$1:string",
-      "get $1(): string {",
-      "  return this._$1;",
-      "}",
-      "set $1(value): string {",
-      "  this._$1;= value",
-      "}"
+      "private _$1: $2",
+      "get $1(): $2 {",
+      "  return this._$1",
+      "}", 
+      "set $1(value: $2) {",
+      "  this._$1 = value",
+    "}"
     ],
     "description": "this will create a getter"
   },


### PR DESCRIPTION
Hi Chris.
there was a problem with the position of the closing parenthesis in the class-setters.
I also added variable typing. What do you think about that?
Best Regards,
 Volker